### PR TITLE
fix: error with text 350760

### DIFF
--- a/app/assets/js/apps/TextViewApp.vue
+++ b/app/assets/js/apps/TextViewApp.vue
@@ -502,9 +502,13 @@ export default {
             return links
         },
         people: function() {
-            return this.text.ancient_person.filter(
-                person => person?.role && person?.role.length // && !['Unknown','unknown'].includes(person.role)
-            )
+            if (this.text.ancient_person) {
+                return this.text.ancient_person.filter(
+                    person => person?.role && person?.role.length // && !['Unknown','unknown'].includes(person.role)
+                )
+            }
+            return [];
+
         },
         annotationsByTypeId() {
             let result = []


### PR DESCRIPTION
There was always an error when opening text with id 350760. The error was caused by that that having a null value for the ancient_person field. Added a check to fix that.