### PR TITLE
'type formulaicity' and 'type reconstruction'

### DIFF
--- a/app/assets/js/components/Search/Config.js
+++ b/app/assets/js/components/Search/Config.js
@@ -430,7 +430,8 @@ export default {
                     ...['morpho_syntactical_coherenceForm', 'morpho_syntactical_coherenceContent', 'morpho_syntactical_coherenceContext',
                         'morpho_syntactical_complementationForm', 'morpho_syntactical_complementationContent', 'morpho_syntactical_complementationContext',
                         'morpho_syntactical_subordinationForm', 'morpho_syntactical_subordinationContent', 'morpho_syntactical_subordinationContext',
-                        'morpho_syntactical_relativisationForm', 'morpho_syntactical_relativisationContent', 'morpho_syntactical_relativisationContext'
+                        'morpho_syntactical_relativisationForm', 'morpho_syntactical_relativisationContent', 'morpho_syntactical_relativisationContext',
+                        'morpho_syntactical_typeFormulaicity', 'morpho_syntactical_typeReconstruction'
                     ].map(
                         field => [
                             this.createOperators(field + '_op', {
@@ -441,6 +442,7 @@ export default {
                             this.createMultiSelect(this.formatPropertyLabel(field, 'morpho_syntactical'), {
                                 model: field,
                                 visible: this.annotationFieldVisible
+                                // visible: true,
                             }),
                         ]
                     ).flat(Infinity),

--- a/app/src/Service/ElasticSearch/Search/Configs.php
+++ b/app/src/Service/ElasticSearch/Search/Configs.php
@@ -30,7 +30,7 @@ class Configs implements SearchConfigInterface
                 'complementationForm', 'complementationContent', 'complementationContext',
                 'subordinationForm', 'subordinationContent', 'subordinationContext',
                 'relativisationForm', 'relativisationContent', 'relativisationContext',
-                'typeFormulaicity'
+                'typeFormulaicity', 'typeReconstruction'
             ],
             'handshift' => ['abbreviation','accentuation','connectivity','correction','curvature','degreeOfFormality','expansion','lineation','orientation','punctuation','regularity','scriptType','slope','wordSplitting', 'status'],
             'gts' => ['part'],


### PR DESCRIPTION
added fields 'type formulaicity' and 'type reconstruction' to lexicogrammar > syntax

closes [#103](https://github.ugent.be/GhentCDH/Evwrit-web/issues/103)