### PR TITLE
Fix clickable details

### DIFF
--- a/app/.env.local
+++ b/app/.env.local
@@ -3,3 +3,5 @@ VUE_APP_LTSA_URL=/textstructure/search
 VUE_APP_ORTHOGRAPHY_URL=/annotation/orthotypo/search
 VUE_APP_TYPOGRAPHY_URL=/annotation/orthotypo/search
 VUE_APP_SYNTAX_URL=/annotation/linguistic/search
+VUE_APP_MORPHOLOGY_URL=/annotation/linguistic/search
+VUE_APP_LEXIS_URL=/annotation/linguistic/search

--- a/app/.env.local
+++ b/app/.env.local
@@ -5,3 +5,4 @@ VUE_APP_TYPOGRAPHY_URL=/annotation/orthotypo/search
 VUE_APP_SYNTAX_URL=/annotation/linguistic/search
 VUE_APP_MORPHOLOGY_URL=/annotation/linguistic/search
 VUE_APP_LEXIS_URL=/annotation/linguistic/search
+VUE_APP_LANGUAGE_URL=/annotation/language/search

--- a/app/.env.local
+++ b/app/.env.local
@@ -1,0 +1,5 @@
+VUE_APP_GTSA_URL=/textstructure/search
+VUE_APP_LTSA_URL=/textstructure/search
+VUE_APP_ORTHOGRAPHY_URL=/annotation/orthotypo/search
+VUE_APP_TYPOGRAPHY_URL=/annotation/orthotypo/search
+VUE_APP_SYNTAX_URL=/annotation/linguistic/search

--- a/app/assets/js/components/Annotations/AnnotationDetails.vue
+++ b/app/assets/js/components/Annotations/AnnotationDetails.vue
@@ -110,6 +110,7 @@ export default {
                 'syntax': process.env.VUE_APP_SYNTAX_URL,
                 'morphology': process.env.VUE_APP_MORPHOLOGY_URL,
                 'lexis': process.env.VUE_APP_LEXIS_URL,
+                'language': process.env.VUE_APP_LANGUAGE_URL,
             }
         }
     },
@@ -155,13 +156,10 @@ export default {
             return this.propertyClasses[prop] ?? [];
         },
         generateUrl(type, filter) {
-            console.log(type)
-            console.log(filter)
-            console.log(process.env.VUE_APP_LEXIS_URL)
             if (type in this.urls){
                 return  (value) => {
                     let filters = [];
-                    if (/^(typography)|(orthography)|(morphology)|(lexis)_.*$/.test(filter)){
+                    if (/^(typography)|(orthography)|(morphology)|(lexis)|(language)_.*$/.test(filter)){
                         filters.push(qs.stringify( { filters: {["annotation_type"]: this.annotation.type} } ) )
                     }
                     if (type === "syntax") {

--- a/app/assets/js/components/Annotations/AnnotationDetails.vue
+++ b/app/assets/js/components/Annotations/AnnotationDetails.vue
@@ -108,6 +108,8 @@ export default {
                 'orthography': process.env.VUE_APP_ORTHOGRAPHY_URL,
                 'typography': process.env.VUE_APP_TYPOGRAPHY_URL,
                 'syntax': process.env.VUE_APP_SYNTAX_URL,
+                'morphology': process.env.VUE_APP_MORPHOLOGY_URL,
+                'lexis': process.env.VUE_APP_LEXIS_URL,
             }
         }
     },
@@ -153,10 +155,13 @@ export default {
             return this.propertyClasses[prop] ?? [];
         },
         generateUrl(type, filter) {
+            console.log(type)
+            console.log(filter)
+            console.log(process.env.VUE_APP_LEXIS_URL)
             if (type in this.urls){
                 return  (value) => {
                     let filters = [];
-                    if (/^(typography)|(orthography)_.*$/.test(filter)){
+                    if (/^(typography)|(orthography)|(morphology)|(lexis)_.*$/.test(filter)){
                         filters.push(qs.stringify( { filters: {["annotation_type"]: this.annotation.type} } ) )
                     }
                     if (type === "syntax") {

--- a/app/assets/js/components/Search/Config.js
+++ b/app/assets/js/components/Search/Config.js
@@ -442,7 +442,7 @@ export default {
                     ).flat(Infinity),
 
                     // morphology
-                    ...['morphology_standardForm', 'morphology_type', 'morphology_subtype', 'morphology_wordclass', 'morphology_formulaicity', 'morphology_positionInWord', 'morphology_prescription'].map(
+                    ...['morphology_standardForm', 'morphology_type', 'morphology_subtype', 'morphology_wordclass', 'morphology_formulaicity', 'morphology_positionInWord'].map(
                         field => [
                             this.createOperators(field + '_op', {
                                 collapsible: true,

--- a/app/assets/js/components/Search/Config.js
+++ b/app/assets/js/components/Search/Config.js
@@ -356,7 +356,7 @@ export default {
                         label: 'Text',
                         model: 'annotation_text',
                     },
-                    defaultAnnotationType !== 'language' ? this.createMultiSelect('Type',
+                    defaultAnnotationType !== 'language' ? this.createSelect('Type',
                         {
                             model: 'annotation_type',
                             styleClasses: 'mbottom-large',
@@ -442,7 +442,7 @@ export default {
                     ).flat(Infinity),
 
                     // morphology
-                    ...['morphology_standardForm', 'morphology_type', 'morphology_subtype', 'morphology_wordclass', 'morphology_formulaicity', 'morphology_positionInWord'].map(
+                    ...['morphology_standardForm', 'morphology_type', 'morphology_subtype', 'morphology_wordclass', 'morphology_formulaicity', 'morphology_positionInWord', 'morphology_prescription'].map(
                         field => [
                             this.createOperators(field + '_op', {
                                 collapsible: true,

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -62,6 +62,8 @@ Encore.configureDefinePlugin(options => {
         VUE_APP_ORTHOGRAPHY_URL: JSON.stringify(process.env.VUE_APP_ORTHOGRAPHY_URL),
         VUE_APP_TYPOGRAPHY_URL: JSON.stringify(process.env.VUE_APP_TYPOGRAPHY_URL),
         VUE_APP_SYNTAX_URL: JSON.stringify(process.env.VUE_APP_SYNTAX_URL),
+        VUE_APP_MORPHOLOGY_URL: JSON.stringify(process.env.VUE_APP_MORPHOLOGY_URL),
+        VUE_APP_LEXIS_URL: JSON.stringify(process.env.VUE_APP_LEXIS_URL),
     };
 });
 

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -64,6 +64,7 @@ Encore.configureDefinePlugin(options => {
         VUE_APP_SYNTAX_URL: JSON.stringify(process.env.VUE_APP_SYNTAX_URL),
         VUE_APP_MORPHOLOGY_URL: JSON.stringify(process.env.VUE_APP_MORPHOLOGY_URL),
         VUE_APP_LEXIS_URL: JSON.stringify(process.env.VUE_APP_LEXIS_URL),
+        VUE_APP_LANGUAGE_URL: JSON.stringify(process.env.VUE_APP_LANGUAGE_URL)
     };
 });
 


### PR DESCRIPTION
In my previous pr #37 I forgot to add the .env.local file for the clickable details urls.
Also makes morphology, lexis and language annotations clickable that I also forgot.
